### PR TITLE
fix:  add missing api document link

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -34,6 +34,9 @@
   - [한국자산관리공사\_온비드 캠코공매물건 조회서비스](https://www.data.go.kr/data/15000851/openapi.do)
   - [한국자산관리공사\_온비드 이용기관 공매물건 조회서비스](https://www.data.go.kr/data/15000849/openapi.do)
   - [한국자산관리공사\_온비드 코드 조회서비스](https://www.data.go.kr/data/15000920/openapi.do)
+  - [한국자산관리공사\_온비드 물건 정보 조회서비스](https://www.data.go.kr/data/15000837/openapi.do)
+  - [한국자산관리공사\_차세대 온비드 물건 입찰결과목록 조회서비스](https://www.data.go.kr/data/15157252/openapi.do)
+  - [한국자산관리공사\_차세대 온비드 물건 입찰결과상세 조회서비스](https://www.data.go.kr/data/15157254/openapi.do)
   - [한국부동산원_청약홈_APT 분양정보](https://www.data.go.kr/data/15101046/fileData.do)
   - [한국부동산원_청약홈 청약 신청·당첨자 정보 조회 서비스](https://www.data.go.kr/data/15110812/openapi.do)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Provides 14+ tools for querying apartment, officetel, villa, single-house, and c
   - [한국자산관리공사\_온비드 캠코공매물건 조회서비스](https://www.data.go.kr/data/15000851/openapi.do)
   - [한국자산관리공사\_온비드 이용기관 공매물건 조회서비스](https://www.data.go.kr/data/15000849/openapi.do)
   - [한국자산관리공사\_온비드 코드 조회서비스](https://www.data.go.kr/data/15000920/openapi.do)
+  - [한국자산관리공사\_온비드 물건 정보 조회서비스](https://www.data.go.kr/data/15000837/openapi.do)
+  - [한국자산관리공사\_차세대 온비드 물건 입찰결과목록 조회서비스](https://www.data.go.kr/data/15157252/openapi.do)
+  - [한국자산관리공사\_차세대 온비드 물건 입찰결과상세 조회서비스](https://www.data.go.kr/data/15157254/openapi.do)
   - [한국부동산원_청약홈_APT 분양정보](https://www.data.go.kr/data/15101046/fileData.do)
   - [한국부동산원_청약홈 청약 신청·당첨자 정보 조회 서비스](https://www.data.go.kr/data/15110812/openapi.do)
 


### PR DESCRIPTION
#3 티켓에서 확인한 이슈에 대해 pr을 생성합니다.

저의 클로드에서 공매물건 조회 시도 시에 호출하는 tool 중 403이나 서비스에러가 발생하는 tool들에 대해 좀 더 확인해보았습니다.

아래 api주소를 호출하는 tool들이 실패하는 것을 확인했습니다.

- _ONBID_BID_RESULT_LIST_URL
- _ONBID_BID_RESULT_DETAIL_URL
- _ONBID_THING_INFO_LIST_URL

리드미에서 신청해야하는 온비드 관련 문서들을 다 확인했는데 상기 3개의 호출주소가 기재된 문서는 없어서 다시 데이터포털에서 찾아보고, 권한신청해야하는 문서들을 추가로 확인했습니다.

다만 아직 api권한처리가 제대로 안되었는지 잘 호출되는지 여부까지는 체크가 안되었습니다.
제작자님께서 더블체크해주시면 좋겠고, 추가로 다른 엔드포인트에서 대해서 권한을 얻어야하는데 목록에서 누락된 문서 없는지도 재확인해주시면 좋겠습니다.

---

아울러 차세대 서비스의 경우 4월까지는 테스트중이라 실제 물건들과 결과가 다를 수 있음을 문서에서 확인하고 있습니다.
- https://www.data.go.kr/data/15157252/openapi.do
- https://www.data.go.kr/data/15157254/openapi.do

실제로 사용에 문제가 있진 않으셨는지, 조회되는 매물과 실제 온비드 사이트에서 조회하는 매물간의 차이는 없으셨는지 궁금합니다.
