### PR TITLE
feat: 기업망 환경용 TLS/SSL 검증 설정 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ DATA_GO_KR_API_KEY=your_api_key_here
 # - Onbid next-gen (B010003): by default this project reuses DATA_GO_KR_API_KEY.
 # ONBID_API_KEY=your_onbid_api_key_here
 
+# TLS options for corporate proxy / SSL inspection environments:
+# - Prefer setting a CA bundle that includes your corporate root/intermediate certs.
+# REAL_ESTATE_SSL_CA_BUNDLE=/path/to/corporate-ca-bundle.pem
+# - On macOS, automatically build a CA bundle from System/login keychains (default: enabled).
+# REAL_ESTATE_USE_MACOS_KEYCHAIN_CA=1
+# - Last resort only: disable SSL verification for HTTPS APIs.
+# REAL_ESTATE_INSECURE_SSL=0
+
 # Auth mode for HTTP/Docker deployment (default: none).
 #   none  — no authentication; use for development or trusted networks
 #   oauth — OAuth 2.0; required for Claude Web / ChatGPT Web OAuth inputs

--- a/tests/mcp_server/test_ssl_config.py
+++ b/tests/mcp_server/test_ssl_config.py
@@ -1,0 +1,38 @@
+"""Tests for SSL verification configuration helpers."""
+
+from real_estate.mcp_server import _helpers
+
+
+def test_resolve_ssl_verify_returns_false_when_insecure_enabled(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("REAL_ESTATE_INSECURE_SSL", "1")
+    monkeypatch.delenv("REAL_ESTATE_SSL_CA_BUNDLE", raising=False)
+    assert _helpers._resolve_ssl_verify() is False
+
+
+def test_resolve_ssl_verify_prefers_ca_bundle_env(monkeypatch) -> None:
+    monkeypatch.delenv("REAL_ESTATE_INSECURE_SSL", raising=False)
+    monkeypatch.setenv("REAL_ESTATE_SSL_CA_BUNDLE", "/tmp/company-ca.pem")
+    monkeypatch.setattr(_helpers, "_create_ssl_context", lambda path: f"CTX::{path}")
+    assert _helpers._resolve_ssl_verify() == "CTX::/tmp/company-ca.pem"
+
+
+def test_resolve_ssl_verify_uses_macos_bundle_when_enabled(monkeypatch) -> None:
+    monkeypatch.delenv("REAL_ESTATE_INSECURE_SSL", raising=False)
+    monkeypatch.delenv("REAL_ESTATE_SSL_CA_BUNDLE", raising=False)
+    monkeypatch.setenv("REAL_ESTATE_USE_MACOS_KEYCHAIN_CA", "1")
+    monkeypatch.setattr(_helpers, "_create_ssl_context", lambda path: f"CTX::{path}")
+    monkeypatch.setattr(
+        _helpers,
+        "_get_macos_keychain_ca_bundle",
+        lambda: "/tmp/macos-keychain-ca.pem",
+    )
+    assert _helpers._resolve_ssl_verify() == "CTX::/tmp/macos-keychain-ca.pem"
+
+
+def test_resolve_ssl_verify_returns_true_when_no_override(monkeypatch) -> None:
+    monkeypatch.delenv("REAL_ESTATE_INSECURE_SSL", raising=False)
+    monkeypatch.delenv("REAL_ESTATE_SSL_CA_BUNDLE", raising=False)
+    monkeypatch.setenv("REAL_ESTATE_USE_MACOS_KEYCHAIN_CA", "0")
+    assert _helpers._resolve_ssl_verify() is True


### PR DESCRIPTION
## 배경
- 안녕하세요, 좋은 mcp를 만들어주셔서 감사합니다.
- 회사 PC/사내 보안 환경(SSL 검사/프록시)에서 외부 HTTPS 호출 시 `certificate verify failed: unable to get local issuer certificate` 에러가 발생했습니다. (real-estate-mcp의 공공 API 호출 안정성 개선 필요)
- 회사에서 okta, zscaler 등의 보안 솔루션을 사용하는데, TLS 검증 관련해서 문제가 발생하여 이를 수정하였습니다.

## 변경 사항
- TLS 검증 전략을 환경변수 기반으로 분기하도록 개선했습니다.
- 공통 `httpx.AsyncClient` 생성 함수를 도입해 `_fetch_xml`, `_fetch_json`에 동일한 SSL 설정이 적용되도록 정리했습니다.
- macOS 환경에서 시스템/로그인 키체인 인증서를 PEM 번들로 생성해 검증에 활용하는 fallback을 추가했습니다.
- SSL 관련 설정값을 `.env.example`에 문서화했습니다.
- SSL 분기 로직에 대한 단위 테스트를 추가했습니다.

## 상세 변경
- `src/real_estate/mcp_server/_helpers.py`
- `_is_truthy` 유틸 추가
- `_resolve_ssl_verify` 추가
- 우선순위:
1. `REAL_ESTATE_INSECURE_SSL=1` 이면 검증 비활성화(`verify=False`)
2. `REAL_ESTATE_SSL_CA_BUNDLE` 지정 시 해당 CA 번들로 SSLContext 생성
3. `REAL_ESTATE_USE_MACOS_KEYCHAIN_CA=1`(기본값)일 때 macOS keychain 기반 CA 번들 시도
4. 위 조건이 없으면 기본 검증(`verify=True`)
- `_get_macos_keychain_ca_bundle` 추가 (`security find-certificate` 사용, 결과 캐시)
- `_build_async_client` 추가 후 기존 fetch 함수에서 공통 사용

- `.env.example`
- `REAL_ESTATE_SSL_CA_BUNDLE`
- `REAL_ESTATE_USE_MACOS_KEYCHAIN_CA`
- `REAL_ESTATE_INSECURE_SSL`
- 각 옵션의 사용 의도/주의사항 주석 추가

- `tests/mcp_server/test_ssl_config.py`
- insecure 모드 활성화 시 `False` 반환 검증
- CA 번들 환경변수 우선 적용 검증
- macOS keychain fallback 적용 검증
- override 없을 때 기본 `True` 검증

## 기대 효과
- 사내 SSL 검사 환경에서 인증서 검증 실패 확률 감소
- 운영 환경별 TLS 설정 유연성 확보
- 기존 기본 보안 동작(`verify=True`)은 유지

## 운영/보안 유의사항
- `REAL_ESTATE_INSECURE_SSL=1`은 최후 수단으로만 사용해야 합니다.
- 가능하면 `REAL_ESTATE_SSL_CA_BUNDLE`에 사내 루트/중간 인증서를 설정하는 방식을 권장합니다.

## 테스트
- 실행 명령:
  - `UV_CACHE_DIR=/tmp/uv-cache PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='--no-cov -p no:cacheprovider' uv run pytest -q tests/mcp_server/test_ssl_config.py`
- 결과:
  - `4 passed in 0.38s`

