### PR TITLE
[MAINTENANCE] test: close mcp-tool-inventory gaps

### DIFF
--- a/src/real_estate/mcp_server/server.py
+++ b/src/real_estate/mcp_server/server.py
@@ -18,6 +18,9 @@ Tools:
   - get_apt_subscription_info: applyhome (청약홈) APT subscription notice metadata
   - get_apt_subscription_results: applyhome (청약홈) subscription stats
     (requests, winners, rates, scores)
+  - calculate_loan_payment: monthly/total loan payment and interest
+  - calculate_compound_growth: compound growth projection with monthly contributions
+  - calculate_monthly_cashflow: monthly cashflow after loan payment and living costs
 
 Korean housing-type keyword mapping (for tool selection):
   - "아파트" → get_apartment_trades / get_apartment_rent

--- a/tests/mcp_server/test_apartment_rent.py
+++ b/tests/mcp_server/test_apartment_rent.py
@@ -178,3 +178,14 @@ class TestGetApartmentRent:
         result = await get_apartment_rent("11440", "202501")
 
         assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error."""
+        import httpx as _httpx
+
+        respx.get(_API_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_apartment_rent("11440", "202501")
+
+        assert result["error"] == "network_error"

--- a/tests/mcp_server/test_commercial_trade.py
+++ b/tests/mcp_server/test_commercial_trade.py
@@ -145,3 +145,14 @@ class TestGetCommercialTrade:
         result = await get_commercial_trade("11440", "202501")
 
         assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error."""
+        import httpx as _httpx
+
+        respx.get(_API_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_commercial_trade("11440", "202501")
+
+        assert result["error"] == "network_error"

--- a/tests/mcp_server/test_officetel_trades.py
+++ b/tests/mcp_server/test_officetel_trades.py
@@ -176,3 +176,42 @@ class TestGetOfficetelTools:
         result = await get_officetel_trades("11440", "202501")
 
         assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_rent_no_data_error(self) -> None:
+        """No-data response returns api_error for rent tool."""
+        respx.get(_RENT_URL).mock(return_value=Response(200, text=_XML_NO_DATA))
+
+        result = await get_officetel_rent("11440", "200001")
+
+        assert result["error"] == "api_error"
+
+    async def test_rent_missing_key_config_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Missing API key returns config_error for rent tool."""
+        monkeypatch.delenv("DATA_GO_KR_API_KEY", raising=False)
+
+        result = await get_officetel_rent("11440", "202501")
+
+        assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_trade_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error for trade tool."""
+        import httpx as _httpx
+
+        respx.get(_TRADE_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_officetel_trades("11440", "202501")
+
+        assert result["error"] == "network_error"
+
+    @respx.mock
+    async def test_rent_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error for rent tool."""
+        import httpx as _httpx
+
+        respx.get(_RENT_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_officetel_rent("11440", "202501")
+
+        assert result["error"] == "network_error"

--- a/tests/mcp_server/test_subscription.py
+++ b/tests/mcp_server/test_subscription.py
@@ -58,6 +58,16 @@ class TestGetAptSubscriptionInfo:
         assert result["error"] == "validation_error"
 
     @respx.mock
+    async def test_timeout_returns_network_error(self) -> None:
+        import httpx as _httpx
+
+        respx.get(_INFO_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_apt_subscription_info()
+
+        assert result["error"] == "network_error"
+
+    @respx.mock
     async def test_service_key_mode_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ODCLOUD_API_KEY", raising=False)
         monkeypatch.setenv("ODCLOUD_SERVICE_KEY", "test-service-key")
@@ -139,6 +149,86 @@ class TestGetAptSubscriptionResults:
         result = await get_apt_subscription_results(stat_kind="nope")
         assert result["error"] == "validation_error"
 
+    @respx.mock
+    async def test_success_reqst_age(self) -> None:
+        payload = {
+            "currentCount": 1,
+            "data": [{"STAT_DE": "202501", "AGE_30": 5}],
+            "matchCount": 1,
+            "page": 1,
+            "perPage": 10,
+            "totalCount": 1,
+        }
+        respx.get(f"{_STAT_BASE_URL}/getAPTReqstAgeStat").mock(
+            return_value=Response(200, json=payload)
+        )
+
+        result = await get_apt_subscription_results(stat_kind="reqst_age")
+
+        assert "error" not in result
+        assert result["stat_kind"] == "reqst_age"
+        assert result["total_count"] == 1
+
+    @respx.mock
+    async def test_success_przwner_area(self) -> None:
+        payload = {
+            "currentCount": 1,
+            "data": [{"STAT_DE": "202501", "SUBSCRPT_AREA_CODE": "01"}],
+            "matchCount": 1,
+            "page": 1,
+            "perPage": 10,
+            "totalCount": 1,
+        }
+        respx.get(f"{_STAT_BASE_URL}/getAPTPrzwnerAreaStat").mock(
+            return_value=Response(200, json=payload)
+        )
+
+        result = await get_apt_subscription_results(stat_kind="przwner_area")
+
+        assert "error" not in result
+        assert result["stat_kind"] == "przwner_area"
+        assert result["total_count"] == 1
+
+    @respx.mock
+    async def test_success_przwner_age(self) -> None:
+        payload = {
+            "currentCount": 1,
+            "data": [{"STAT_DE": "202501", "AGE_30": 3}],
+            "matchCount": 1,
+            "page": 1,
+            "perPage": 10,
+            "totalCount": 1,
+        }
+        respx.get(f"{_STAT_BASE_URL}/getAPTPrzwnerAgeStat").mock(
+            return_value=Response(200, json=payload)
+        )
+
+        result = await get_apt_subscription_results(stat_kind="przwner_age")
+
+        assert "error" not in result
+        assert result["stat_kind"] == "przwner_age"
+        assert result["total_count"] == 1
+
+    @respx.mock
+    async def test_success_cmpetrt_area(self) -> None:
+        payload = {
+            "currentCount": 1,
+            "data": [{"STAT_DE": "202501", "SUBSCRPT_AREA_CODE": "01", "CMPET_RATE": "3.5"}],
+            "matchCount": 1,
+            "page": 1,
+            "perPage": 10,
+            "totalCount": 1,
+        }
+        respx.get(f"{_STAT_BASE_URL}/getAPTCmpetrtAreaStat").mock(
+            return_value=Response(200, json=payload)
+        )
+
+        result = await get_apt_subscription_results(stat_kind="cmpetrt_area")
+
+        assert "error" not in result
+        assert result["stat_kind"] == "cmpetrt_area"
+        assert result["total_count"] == 1
+
     async def test_invalid_page_returns_validation_error(self) -> None:
         result = await get_apt_subscription_results(stat_kind="reqst_area", page=0)
         assert result["error"] == "validation_error"
@@ -202,3 +292,15 @@ class TestGetAptSubscriptionResults:
 
         assert "error" not in result
         assert result["total_count"] == 1
+
+    @respx.mock
+    async def test_timeout_returns_network_error(self) -> None:
+        import httpx as _httpx
+
+        respx.get(f"{_STAT_BASE_URL}/getAPTReqstAreaStat").mock(
+            side_effect=_httpx.TimeoutException("timeout")
+        )
+
+        result = await get_apt_subscription_results(stat_kind="reqst_area")
+
+        assert result["error"] == "network_error"

--- a/tests/mcp_server/test_villa_single_house.py
+++ b/tests/mcp_server/test_villa_single_house.py
@@ -339,3 +339,104 @@ class TestVillaSingleHouseTools:
         result = await get_villa_trades("11440", "202501")
 
         assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_single_house_trades_no_data_error(self) -> None:
+        """No-data response returns api_error for single house trades."""
+        respx.get(_SINGLE_TRADE_URL).mock(return_value=Response(200, text=_XML_NO_DATA))
+
+        result = await get_single_house_trades("11440", "200001")
+
+        assert result["error"] == "api_error"
+
+    async def test_single_house_trades_missing_key_config_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing API key returns config_error for single house trades."""
+        monkeypatch.delenv("DATA_GO_KR_API_KEY", raising=False)
+
+        result = await get_single_house_trades("11440", "202501")
+
+        assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_villa_rent_no_data_error(self) -> None:
+        """No-data response returns api_error for villa rent."""
+        respx.get(_VILLA_RENT_URL).mock(return_value=Response(200, text=_XML_NO_DATA))
+
+        result = await get_villa_rent("11440", "200001")
+
+        assert result["error"] == "api_error"
+
+    async def test_villa_rent_missing_key_config_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing API key returns config_error for villa rent."""
+        monkeypatch.delenv("DATA_GO_KR_API_KEY", raising=False)
+
+        result = await get_villa_rent("11440", "202501")
+
+        assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_single_house_rent_no_data_error(self) -> None:
+        """No-data response returns api_error for single house rent."""
+        respx.get(_SINGLE_RENT_URL).mock(return_value=Response(200, text=_XML_NO_DATA))
+
+        result = await get_single_house_rent("11440", "200001")
+
+        assert result["error"] == "api_error"
+
+    async def test_single_house_rent_missing_key_config_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing API key returns config_error for single house rent."""
+        monkeypatch.delenv("DATA_GO_KR_API_KEY", raising=False)
+
+        result = await get_single_house_rent("11440", "202501")
+
+        assert result["error"] == "config_error"
+
+    @respx.mock
+    async def test_villa_trades_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error for villa trades."""
+        import httpx as _httpx
+
+        respx.get(_VILLA_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_villa_trades("11440", "202501")
+
+        assert result["error"] == "network_error"
+
+    @respx.mock
+    async def test_villa_rent_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error for villa rent."""
+        import httpx as _httpx
+
+        respx.get(_VILLA_RENT_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_villa_rent("11440", "202501")
+
+        assert result["error"] == "network_error"
+
+    @respx.mock
+    async def test_single_house_trades_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error for single house trades."""
+        import httpx as _httpx
+
+        respx.get(_SINGLE_TRADE_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_single_house_trades("11440", "202501")
+
+        assert result["error"] == "network_error"
+
+    @respx.mock
+    async def test_single_house_rent_timeout_returns_network_error(self) -> None:
+        """A timeout returns a network_error for single house rent."""
+        import httpx as _httpx
+
+        respx.get(_SINGLE_RENT_URL).mock(side_effect=_httpx.TimeoutException("timeout"))
+
+        result = await get_single_house_rent("11440", "202501")
+
+        assert result["error"] == "network_error"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
An internal audit of this repo's MCP tools found four test-coverage and documentation gaps. This PR closes all four:

1. **Missing docstring entries** — the `server.py` module docstring lists all MCP tools for discoverability, but the 3 `calculate_*` finance tools (`calculate_loan_payment`, `calculate_compound_growth`, `calculate_monthly_cashflow`) were missing from it. Added the missing 3 lines.
2. **Error paths untested** — 4 tools (`get_single_house_trades`, `get_officetel_rent`, `get_villa_rent`, `get_single_house_rent`) only had tests for the success path. Added tests for the no-data-returned case (`api_error`) and the missing-API-key case (`config_error`) for each.
3. **Unverified `stat_kind` values** — `get_apt_subscription_results` accepts 6 `stat_kind` values, but only 2 had passing-case tests. Added success-case tests for the remaining 4 (`reqst_age`, `przwner_area`, `przwner_age`, `cmpetrt_area`).
4. **Missing timeout tests** — only 1 of the 11 tools that make outbound network calls had a test for the request-timeout case. Added a timeout (`network_error`) test to the other 10.

A fifth gap (contract tests against the *real*, unmocked government API) was identified but deliberately left out of this PR — it needs a live API key and real network calls, which raises CI cost/stability concerns and deserves its own PR with that tradeoff discussed explicitly.

No existing behavior changed: the only production code touched is the 3 added docstring lines in `server.py`; everything else is new tests.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Test coverage additions + one docstring fix. No production behavior or public API changed.
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/tae0y/real-estate-mcp.git
cd real-estate-mcp
git checkout worktree-close-inventory-gaps
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
uv run pytest
uv run ruff check --fix && uv run ruff format
uv run pyright
uv run bandit -c pyproject.toml -r src/
```

## What to Check
Verify that the following are valid
* `uv run pytest` passes — 121 passed, coverage 85.02% (above the 80% threshold)
* `server.py` module docstring now lists all 3 `calculate_*` tools
* No production code changed other than the 3 added docstring lines

## Other Information
<!-- Add any other helpful information that may be needed here. -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)
