### PR TITLE
[BUG] docs: fix docker compose --env-file for CLOUDFLARE_TUNNEL_TOKEN

### DIFF
--- a/docs/setup-reverse-proxy.md
+++ b/docs/setup-reverse-proxy.md
@@ -60,14 +60,10 @@ No port forwarding or TLS certificate management required.
 1. Start the containers.
 
     ```bash
-    # bash/zsh
-    docker compose -f docker/docker-compose.yml --profile cloudflare up -d --build
+    docker compose --env-file .env -f docker/docker-compose.yml --profile cloudflare up -d --build
     ```
 
-    ```powershell
-    # PowerShell
-    docker compose -f docker/docker-compose.yml --profile cloudflare up -d --build
-    ```
+    > **Important:** `--env-file .env` is required because Compose v2 otherwise treats the compose file's directory (`docker/`) as the project directory and looks for `docker/.env` instead of the root `.env`, leaving `CLOUDFLARE_TUNNEL_TOKEN` blank. `--env-file` is a global flag and must come before `up`.
 
     The `cloudflared` service depends on the `mcp` health check passing, so it starts roughly 15–45 seconds after Docker Compose begins. Once both containers are running, the tunnel status in the Cloudflare dashboard changes to **Healthy**.
 
@@ -81,13 +77,7 @@ No port forwarding or TLS certificate management required.
 1. Stop and remove the containers.
 
     ```bash
-    # bash/zsh
-    docker compose -f docker/docker-compose.yml --profile cloudflare down
-    ```
-
-    ```powershell
-    # PowerShell
-    docker compose -f docker/docker-compose.yml --profile cloudflare down
+    docker compose --env-file .env -f docker/docker-compose.yml --profile cloudflare down
     ```
 
 1. In the Cloudflare Zero Trust dashboard → **Networks** → **Tunnels**, select the tunnel → **Delete**.

--- a/docs/setup-with-http.md
+++ b/docs/setup-with-http.md
@@ -8,7 +8,6 @@ This page describes how to connect to the real estate MCP server over a public H
 - [x] Claude CLI — connects via `--transport http` with a remote URL
 - [x] Codex CLI — connects via `--url` with a remote URL
 - [x] Claude (Web / Claude.ai) — **primary use case**
-- [x] ChatGPT (Web) — **deprecated**, removed June 1, 2026
 
 ## Prerequisites
 
@@ -65,10 +64,3 @@ codex mcp add real-estate --url https://<subdomain>.<domain>/mcp
 ```bash
 codex mcp remove real-estate
 ```
-
----
-
-## ChatGPT (Web) — deprecated
-
-> **Deprecated:** ChatGPT support will be removed on June 1, 2026.
-> The required OAuth flow (Auth0 + PKCE + DCR) is too complex to maintain reliably — it will be re-evaluated for a future release.

--- a/docs/setup-with-stdio.md
+++ b/docs/setup-with-stdio.md
@@ -8,7 +8,6 @@ This page describes how to connect the real estate MCP server to a local client 
 - [x] Claude CLI — stdio and local HTTP
 - [x] Codex CLI — stdio and local HTTP
 - [ ] Claude (Web / Claude.ai) — requires a public URL; see [setup-with-http.md](setup-with-http.md)
-- [ ] ChatGPT (Web) — requires a public URL; see [setup-with-http.md](setup-with-http.md)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix the documented `docker compose --profile cloudflare` command in `docs/setup-reverse-proxy.md`: Compose v2 treats the compose file's directory (`docker/`) as the project directory, so it looked for `docker/.env` instead of the root `.env`, leaving `CLOUDFLARE_TUNNEL_TOKEN` blank. Add `--env-file .env` to the `up` and `down` commands so the root `.env` is used, and collapse the identical bash/PowerShell blocks into single blocks.
* While auditing the rest of `docs/` for the same class of staleness, remove leftover "ChatGPT (Web)" references from `docs/setup-with-http.md` and `docs/setup-with-stdio.md` — ChatGPT/OAuth support was already removed in #32 but these two docs were missed.

Closes #37

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd real-estate-mcp
git checkout tae0y/bug-docs-docker-compose-command-does-not-load-ro
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cp .env.example .env
# set CLOUDFLARE_TUNNEL_TOKEN in .env

docker compose --env-file .env -f docker/docker-compose.yml --profile cloudflare config
# confirm TUNNEL_TOKEN resolves to the value from the root .env, not a blank string
```

## What to Check
Verify that the following are valid
* `docs/setup-reverse-proxy.md` — the `up`/`down` commands include `--env-file .env` and the bash/PowerShell blocks are merged
* `docs/setup-with-http.md` and `docs/setup-with-stdio.md` no longer reference ChatGPT (Web)
* No other docs reference the removed Caddy reverse proxy or auth server

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* Issue: https://github.com/tae0y/real-estate-mcp/issues/37
